### PR TITLE
Minor define stuff.

### DIFF
--- a/SS12.dme
+++ b/SS12.dme
@@ -15,6 +15,8 @@
 
 // BEGIN_INCLUDE
 #include "code\world.dm"
+#include "code\_DEFINES\maths.dm"
+#include "code\_DEFINES\temporary.dm"
 #include "code\area\area.dm"
 #include "code\area\SS12Areas.dm"
 #include "code\datum\construction_datum.dm"

--- a/code/_DEFINES/maths.dm
+++ b/code/_DEFINES/maths.dm
@@ -1,0 +1,4 @@
+//Defines for usefull procs, using defines to lower CPU usage at runtime.
+
+//Clamps x between y and z, where y is the lower bound and z the upper.
+#define clamp(x, y, z) (x <= y ? y : x >= z ? z : x)

--- a/code/_DEFINES/temporary.dm
+++ b/code/_DEFINES/temporary.dm
@@ -1,0 +1,5 @@
+// These defines are things like being able to use qdel() instead of del without having qdel defined, so switching to a GC when we have one later isn't a PAIN.
+
+// GC stuff, once we have a GC remove these and define the procs, voila!
+#define Destroy Del
+#define qdel del


### PR DESCRIPTION
# defines added for Destroy and qdel, defining Del and del respectively, to make a switch to a GC in the future easier.

Adds a clamp define because that's usefull as hell.
